### PR TITLE
fix: updates failing because of paths being changed to lowercase

### DIFF
--- a/src/detours/utils.rs
+++ b/src/detours/utils.rs
@@ -6,11 +6,12 @@ const KNOWN_ASAR_NAMES: &[&str] = &["_app.asar", "app.orig.asar"];
 
 /// Map original filenames to our modified filenames.
 pub unsafe fn file_name_handler(path: &str) -> String {
-    let asar_toggle_query = std::env::var("MODHOOK_TOGGLE_QUERY").unwrap();
-    let path = path.to_lowercase();
-    let pathbuf = PathBuf::from(&path.clone());
+    let asar_toggle_query = std::env::var("MODHOOK_TOGGLE_QUERY")
+        .unwrap()
+        .to_lowercase();
+    let pathbuf = PathBuf::from(&path);
 
-    if path.contains(&asar_toggle_query) {
+    if path.to_lowercase().contains(&asar_toggle_query) {
         MOD_DONE_LOADING = true;
     }
 

--- a/src/detours/win32.rs
+++ b/src/detours/win32.rs
@@ -26,13 +26,13 @@ static mut O_CREATE_PROCESS_W: *mut c_void = 0 as _;
 
 pub unsafe fn init_detours() {
     O_CREATE_FILE_W = CreateFileW as *mut c_void;
-    DetourAttach(&mut O_CREATE_FILE_W, create_file_w as _);
+    DetourAttach(&raw mut O_CREATE_FILE_W, create_file_w as _);
 
     O_GET_FILE_ATTRIBUTES_W = GetFileAttributesW as *mut c_void;
-    DetourAttach(&mut O_GET_FILE_ATTRIBUTES_W, get_file_attributes_w as _);
+    DetourAttach(&raw mut O_GET_FILE_ATTRIBUTES_W, get_file_attributes_w as _);
 
     O_CREATE_PROCESS_W = CreateProcessW as *mut c_void;
-    DetourAttach(&mut O_CREATE_PROCESS_W, create_process_w as _);
+    DetourAttach(&raw mut O_CREATE_PROCESS_W, create_process_w as _);
 }
 
 unsafe fn create_file_w(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ unsafe extern "stdcall" fn DllMain(
     DetourUpdateThread(GetCurrentThread() as _);
 
     O_ENTRYPOINT = DetourGetEntryPoint(null_mut());
-    DetourAttach(&mut O_ENTRYPOINT, main as _);
+    DetourAttach(&raw mut O_ENTRYPOINT, main as _);
 
     detours::win32::init_detours();
 


### PR DESCRIPTION
Fixes paths being lowercased, causing Discord updates to fail.

Also uses the newly stabilised `&raw mut` instead of `&mut`

Closes #1 